### PR TITLE
Sanitize & unslash acquisition methods #18

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -168,13 +168,15 @@ function edd_acq_save_methods( $input ) {
 
 	$sanitized_methods = array();
 	foreach ( $new_methods as $method ) {
-		if ( empty( $method['name'] ) && empty( $method['value'] ) ) {
+		if ( empty( $method['name'] ) ) {
 			continue;
 		}
 
+		$new_value = ! empty( $method['value'] ) ? $method['value'] : $method['name'];
+
 		$sanitized_methods[] = array(
 			'name' => sanitize_text_field( wp_unslash( $method['name'] ) ),
-			'value' => sanitize_key( $method['value'] )
+			'value' => sanitize_title_with_dashes( $new_value )
 		);
 	}
 

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -147,40 +147,42 @@ function edd_acquisition_methods_callback( $args ) {
 /**
  * Acquisition Methods Sanitization
  *
- * Adds a settings error (for the updated message)
  * This also saves the acquisition methods table
  *
  * @since 1.0
  * @param array $input The value inputted in the field
- * @return string $input Sanitizied value
+ * @return array $input Array of sanitizied values
  */
 function edd_acq_save_methods( $input ) {
 
-	if( ! current_user_can( 'manage_shop_settings' ) ) {
+	if ( ! current_user_can( 'manage_shop_settings' ) ) {
 		return $input;
 	}
 
-	// If our acquisition methods are in the POST, move along.
+	// If our acquisition methods aren't in the POST, move along.
 	if ( ! array_key_exists( 'edd_acq_methods', $_POST ) ) {
 		return $input;
 	}
 
 	$new_methods = ! empty( $_POST['edd_acq_methods'] ) ? array_values( $_POST['edd_acq_methods'] ) : array();
 
-	$saved_methods = array();
-	foreach ( $new_methods as $key => $method ) {
+	$sanitized_methods = array();
+	foreach ( $new_methods as $method ) {
 		if ( empty( $method['name'] ) && empty( $method['value'] ) ) {
-			unset( $new_methods[$key] );
+			continue;
 		}
 
-		if ( ! in_array( $method['value'], $saved_methods ) ) {
-			$saved_methods[] = $method['value'];
-		} else {
-			return $input;
-		}
+		$sanitized_methods[] = array(
+			'name' => sanitize_text_field( wp_unslash( $method['name'] ) ),
+			'value' => sanitize_key( $method['value'] )
+		);
 	}
 
-	update_option( 'edd_acq_methods', $new_methods );
+	if ( ! empty( $sanitized_methods ) ) {
+		update_option( 'edd_acq_methods', $sanitized_methods );
+	} else {
+		delete_option( 'edd_acq_methods' );
+	}
 
 	return $input;
 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -151,7 +151,7 @@ function edd_acquisition_methods_callback( $args ) {
  *
  * @since 1.0
  * @param array $input The value inputted in the field
- * @return array $input Array of sanitizied values
+ * @return array $input Array of sanitized values
  */
 function edd_acq_save_methods( $input ) {
 


### PR DESCRIPTION
Closes #18

- This actually sanitizes the acquisition methods (despite the title, they weren't being sanitized at all...)
- The name gets unslashed, which fixes the original issue.
- If no key is provided, one is generated from the name.
- Keys are run through `sanitize_title_with_dashes`, which basically turns them into slugs.